### PR TITLE
[W2.6e][T09-1] Lee Yu Choy

### DIFF
--- a/src/seedu/addressbook/commands/CommandResult.java
+++ b/src/seedu/addressbook/commands/CommandResult.java
@@ -10,8 +10,7 @@ import java.util.Optional;
  */
 public class CommandResult {
 
-    /** The feedback message to be shown to the user. Contains a description of the execution result */
-    public final String feedbackToUser;
+    private final String feedbackToUser;
 
     /** The list of persons that was produced by the command */
     private final List<? extends ReadOnlyPerson> relevantPersons;
@@ -33,4 +32,8 @@ public class CommandResult {
         return Optional.ofNullable(relevantPersons);
     }
 
+    /** The feedback message to be shown to the user. Contains a description of the execution result */
+    public String getFeedbackToUser() {
+        return feedbackToUser;
+    }
 }

--- a/src/seedu/addressbook/ui/TextUi.java
+++ b/src/seedu/addressbook/ui/TextUi.java
@@ -129,7 +129,7 @@ public class TextUi {
         if (resultPersons.isPresent()) {
             showPersonListView(resultPersons.get());
         }
-        showToUser(result.feedbackToUser, DIVIDER);
+        showToUser(result.getFeedbackToUser(), DIVIDER);
     }
 
     /**

--- a/test/java/seedu/addressbook/commands/AddCommandTest.java
+++ b/test/java/seedu/addressbook/commands/AddCommandTest.java
@@ -126,7 +126,7 @@ public class AddCommandTest {
         assertTrue(people.contains(p));
         assertEquals(1, people.immutableListView().size());
         assertFalse(result.getRelevantPersons().isPresent());
-        assertEquals(String.format(AddCommand.MESSAGE_SUCCESS, p), result.feedbackToUser);
+        assertEquals(String.format(AddCommand.MESSAGE_SUCCESS, p), result.getFeedbackToUser());
     }
 
     @Test
@@ -139,7 +139,7 @@ public class AddCommandTest {
         CommandResult result = command.execute();
 
         assertFalse(result.getRelevantPersons().isPresent());
-        assertEquals(AddCommand.MESSAGE_DUPLICATE_PERSON, result.feedbackToUser);
+        assertEquals(AddCommand.MESSAGE_DUPLICATE_PERSON, result.getFeedbackToUser());
         UniquePersonList people = book.getAllPersons();
         assertTrue(people.contains(p));
         assertEquals(1, people.immutableListView().size());

--- a/test/java/seedu/addressbook/commands/DeleteCommandTest.java
+++ b/test/java/seedu/addressbook/commands/DeleteCommandTest.java
@@ -109,7 +109,7 @@ public class DeleteCommandTest {
 
         CommandResult result = deleteCommand.execute();
 
-        assertEquals(expectedMessage, result.feedbackToUser);
+        assertEquals(expectedMessage, result.getFeedbackToUser());
         assertEquals(expectedAddressBook.getAllPersons(), actualAddressBook.getAllPersons());
     }
 

--- a/test/java/seedu/addressbook/commands/FindCommandTest.java
+++ b/test/java/seedu/addressbook/commands/FindCommandTest.java
@@ -50,7 +50,7 @@ public class FindCommandTest {
         FindCommand command = createFindCommand(keywords);
         CommandResult result = command.execute();
 
-        assertEquals(Command.getMessageForPersonListShownSummary(expectedPersonList), result.feedbackToUser);
+        assertEquals(Command.getMessageForPersonListShownSummary(expectedPersonList), result.getFeedbackToUser());
     }
 
     private FindCommand createFindCommand(String[] keywords) {

--- a/test/java/seedu/addressbook/commands/ViewCommandTest.java
+++ b/test/java/seedu/addressbook/commands/ViewCommandTest.java
@@ -143,7 +143,7 @@ public class ViewCommandTest {
         CommandResult result = viewCommand.execute();
 
         // feedback message is as expected and there are no relevant persons returned.
-        assertEquals(expectedMessage, result.feedbackToUser);
+        assertEquals(expectedMessage, result.getFeedbackToUser());
         assertEquals(Optional.empty(), result.getRelevantPersons());
 
         // addressbook was not modified.


### PR DESCRIPTION
The member `feedbackToUser` is currently exposed to members outside
of the class

Without encapsulation, we cannot prevent illegal direct access of its
member

Let's us encapsulate and hide its data and add a new getter method
which is exposed to the public. This will provide us with a better
flexibility and easier maintainability in the future.